### PR TITLE
Update dbbuilder.py

### DIFF
--- a/python/dbbuilder.py
+++ b/python/dbbuilder.py
@@ -83,6 +83,7 @@ class ThermostatDBBuilder(DBBuilder):
 	def __init__(self, addr, db):
 		self.addr = addr
 		self.db = db
+		self.db.setTopOfDatabase(0x1fff)
 	def msgReceived(self, msg):
 		self.restartTimer()
 		if msg.isPureNack():


### PR DESCRIPTION
Thermostat device has a top of database delimiter set to 0x1fff, while all other devices have 0x0fff