### PR TITLE
Add "Get IM Configuration (0x73)" modem command

### DIFF
--- a/python/modem2413U.py
+++ b/python/modem2413U.py
@@ -35,6 +35,13 @@ class IMInfoMsgHandler(MsgHandler):
 		out(self.name + " got msg: " + msg.toString())
 		return 1
 
+class IMConfigMsgHandler(MsgHandler):
+	def __init__(self, name):
+		self.name = name
+	def processMsg(self, msg):
+		out(self.name + " got msg: " + msg.toString())
+		return 1
+
 class MsgDumper(MsgHandler):
 	def __init__(self, name):
 		self.name = name
@@ -119,6 +126,13 @@ class Modem2413U(Device):
 		self.querier = Querier(InsteonAddress("00.00.00"))
 		self.querier.setMsgHandler(IMInfoMsgHandler("getid"))
 		msg = Msg.s_makeMessage("GetIMInfo")
+		self.querier.sendMsg(msg)
+	def getIMConfig(self):
+		"""getIMConfig()
+		get modem configuration flags byte"""
+		self.querier = Querier(InsteonAddress("00.00.00"))
+		self.querier.setMsgHandler(IMConfigMsgHandler("getIMConfig"))
+		msg = Msg.s_makeMessage("GetIMConfig")
 		self.querier.sendMsg(msg)
 	def sendOn(self, group):
 		"""sendOn(group)

--- a/resources/msg_definitions.xml
+++ b/resources/msg_definitions.xml
@@ -139,6 +139,22 @@
 		<byte name = "FirmwareVersion"/>
 		<byte name = "ACK/NACK"/>
 	</msg>
+	<msg name = "GetIMConfig" length="2" direction = "TO_MODEM">
+		<header length="2">
+		 	<byte>0x02</byte>
+			<byte name = "Cmd">0x73</byte>
+		</header>
+	</msg>
+	<msg name = "GetIMConfigReply" length="6" direction = "FROM_MODEM">
+		<header length="2">
+		 	<byte>0x02</byte>
+			<byte name = "Cmd">0x73</byte>
+		</header>
+		<byte name = "IMConfigurationFlags"/>
+		<byte name = "Spare1"/>
+		<byte name = "Spare2"/>
+		<byte name = "ACK/NACK"/>
+	</msg>
 	<msg name = "SendALLLinkCommand" length="5" direction = "TO_MODEM">
 		<header length="2">
 		 	<byte>0x02</byte>


### PR DESCRIPTION
This change adds support for issuing the "Get IM Configuration (0x73)" modem command to the PLM.

Example output is as follows:

```
>>> modem.getIMConfig()
sent msg: OUT:Cmd:0x73|
>>> getIMConfig got msg: IN:Cmd:0x73|IMConfigurationFlags:0x47|Spare1:0x05|Spare2:0x1E|ACK/NACK:0x06|
```

This was implemented as part of some debugging requested while diagnosing TD22057/insteon-mqtt#351.